### PR TITLE
fixed text in test

### DIFF
--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -15,7 +15,7 @@ describe "#clock_angle(time)" do
     expect(clock_angle("3:15")).to eq(7.5)
   end
 
-  it 'returns the correct angle between the clock hands representing 3:15' do
+  it 'returns the correct angle between the clock hands representing 8:30' do
     expect(clock_angle("8:30")).to eq(75)
   end
 end


### PR DESCRIPTION
The test in angle_spec.rb says "returns the correct angle between the clock hands representing 8:30" two times. The second time it is actually testing for 3:15. I changed the second one's text to match this.